### PR TITLE
Fix AppSettingDict to store FileField values as storage paths instead of pickled files

### DIFF
--- a/djpwr_app_settings/__init__.py
+++ b/djpwr_app_settings/__init__.py
@@ -1,51 +1,145 @@
 import logging
+import os
 
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.files.base import File
+from django.core.files.storage import default_storage
 from django.db import ProgrammingError
-from djpwr.managers import get_model, get_manager
+from django.db.models import FileField
+from django.db.models.fields.files import FieldFile
+from djpwr.managers import get_manager, get_model
 
-default_app_config = 'djpwr.app_settings.apps.AppConfig'
-
+default_app_config = "djpwr.app_settings.apps.AppConfig"
 
 logger = logging.getLogger(__name__)
 
 
+def _setting_model_field(group_name: str, setting_name: str):
+    try:
+        model = get_model(group_name)
+        return model._meta.get_field(setting_name)
+    except Exception:
+        return None
+
+
+def _is_file_setting(group_name: str, setting_name: str) -> bool:
+    field = _setting_model_field(group_name, setting_name)
+    return isinstance(field, FileField)
+
+
+def _storage_path_for(
+    app_label: str, model_name: str, setting_name: str, filename: str
+) -> str:
+    filename = os.path.basename(filename) or "upload"
+    return f"app_settings/{app_label}/{model_name}/{setting_name}/{filename}"
+
+
+def _delete_storage_name(name: str) -> None:
+    if not name:
+        return
+    try:
+        default_storage.delete(name)
+    except Exception:
+        # Never block saving settings on storage delete issues
+        pass
+
+
+def _extract_storage_value(value) -> str:
+    if isinstance(value, (FieldFile, File)):
+        return getattr(value, "name", "") or ""
+    return value
+
+
+def _open_as_django_file(storage_name: str) -> File | None:
+    """
+    Open a stored file path and wrap it as django.core.files.base.File.
+    Caller is responsible for closing it if needed (f.close()).
+    """
+    if not storage_name:
+        return None
+    try:
+        f = default_storage.open(storage_name, "rb")
+        return File(f, name=storage_name)
+    except Exception:
+        return None
+
+
 class AppSettingDict:
     def __getitem__(self, setting_label):
-        app_label, model_name, setting_name = setting_label.split('.')
+        app_label, model_name, setting_name = setting_label.split(".")
+        group_name = ".".join([app_label, model_name])
 
         try:
-            setting = get_manager('app_settings.ApplicationSetting').get(
-                group__group_name='.'.join([app_label, model_name]),
-                name=setting_name
+            setting = get_manager("app_settings.ApplicationSetting").get(
+                group__group_name=group_name,
+                name=setting_name,
             )
         except ProgrammingError:
-            # This exception occurs when the migrations of this app have not been
-            # run yet, as can happen when this app is newly added and this
-            # implementation is called from the code at Python runtime.
             logger.error(
-                f"Catching exception in AppSettingDict.__getitem__ for {setting_label}, "
-                f" please check if migrations for this app have been run."
-
+                "Catching exception in AppSettingDict.__getitem__ for %s, "
+                "please check if migrations for this app have been run.",
+                setting_label,
             )
             return
+        except ObjectDoesNotExist:
+            raise KeyError(setting_label)
 
-        return setting.value
+        value = setting.value
+
+        # If this is a FileField-setting, enforce: stored value == storage path string.
+        if _is_file_setting(group_name, setting_name):
+            storage_value = _extract_storage_value(value)
+            return _open_as_django_file(storage_value)
+
+        return value
 
     def __setitem__(self, setting_label, value):
-        app_label, model_name, setting_name = setting_label.split('.')
+        app_label, model_name, setting_name = setting_label.split(".")
+        group_name = ".".join([app_label, model_name])
 
-        setting_group = get_model('.'.join([app_label, model_name]))
-
-        setting = get_manager('app_settings.ApplicationSetting').get(
-            group__group_name='.'.join([app_label, model_name]),
-            name=setting_name
+        setting = get_manager("app_settings.ApplicationSetting").get(
+            group__group_name=group_name,
+            name=setting_name,
         )
+
+        get_manager("app_settings.SettingGroup").touch_last_modified(setting.group)
+
+        old_storage_value = _extract_storage_value(setting.value)
+
+        # new file upload
+        if isinstance(value, File) and not isinstance(value, FieldFile):
+            _delete_storage_name(old_storage_value)
+
+            storage_path = _storage_path_for(
+                app_label, model_name, setting_name, value.name
+            )
+            saved_name = default_storage.save(storage_path, value)
+
+            setting.value = saved_name
+            setting.save()
+            return
+
+        # user cleared the value. If file, delete the old stored file.
+        if not value:
+            if _is_file_setting(group_name, setting_name):
+                _delete_storage_name(old_storage_value)
+
         setting.value = value
         setting.save()
 
-        get_manager('app_settings.SettingGroup').touch_last_modified(setting.group)
+    def get(self, setting_label, default=None):
+        try:
+            return self[setting_label]
+        except KeyError:
+            return default
+
+    def __contains__(self, setting_label):
+        try:
+            self[setting_label]
+        except KeyError:
+            return False
+        return True
 
 
 app_settings = AppSettingDict()
-
 APP_SETTINGS = app_settings

--- a/djpwr_app_settings/__init__.py
+++ b/djpwr_app_settings/__init__.py
@@ -1,67 +1,14 @@
 import logging
-import os
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.files.base import File
-from django.core.files.storage import default_storage
 from django.db import ProgrammingError
-from django.db.models import FileField
-from django.db.models.fields.files import FieldFile
-from djpwr.managers import get_manager, get_model
+from djpwr.managers import get_manager
+
+from . import files
 
 default_app_config = "djpwr.app_settings.apps.AppConfig"
 
 logger = logging.getLogger(__name__)
-
-
-def _setting_model_field(group_name: str, setting_name: str):
-    try:
-        model = get_model(group_name)
-        return model._meta.get_field(setting_name)
-    except Exception:
-        return None
-
-
-def _is_file_setting(group_name: str, setting_name: str) -> bool:
-    field = _setting_model_field(group_name, setting_name)
-    return isinstance(field, FileField)
-
-
-def _storage_path_for(
-    app_label: str, model_name: str, setting_name: str, filename: str
-) -> str:
-    filename = os.path.basename(filename) or "upload"
-    return f"app_settings/{app_label}/{model_name}/{setting_name}/{filename}"
-
-
-def _delete_storage_name(name: str) -> None:
-    if not name:
-        return
-    try:
-        default_storage.delete(name)
-    except Exception:
-        # Never block saving settings on storage delete issues
-        pass
-
-
-def _extract_storage_value(value) -> str:
-    if isinstance(value, (FieldFile, File)):
-        return getattr(value, "name", "") or ""
-    return value
-
-
-def _open_as_django_file(storage_name: str) -> File | None:
-    """
-    Open a stored file path and wrap it as django.core.files.base.File.
-    Caller is responsible for closing it if needed (f.close()).
-    """
-    if not storage_name:
-        return None
-    try:
-        f = default_storage.open(storage_name, "rb")
-        return File(f, name=storage_name)
-    except Exception:
-        return None
 
 
 class AppSettingDict:
@@ -84,14 +31,7 @@ class AppSettingDict:
         except ObjectDoesNotExist:
             raise KeyError(setting_label)
 
-        value = setting.value
-
-        # If this is a FileField-setting, enforce: stored value == storage path string.
-        if _is_file_setting(group_name, setting_name):
-            storage_value = _extract_storage_value(value)
-            return _open_as_django_file(storage_value)
-
-        return value
+        return setting.value
 
     def __setitem__(self, setting_label, value):
         app_label, model_name, setting_name = setting_label.split(".")
@@ -104,25 +44,9 @@ class AppSettingDict:
 
         get_manager("app_settings.SettingGroup").touch_last_modified(setting.group)
 
-        old_storage_value = _extract_storage_value(setting.value)
-
-        # new file upload
-        if isinstance(value, File) and not isinstance(value, FieldFile):
-            _delete_storage_name(old_storage_value)
-
-            storage_path = _storage_path_for(
-                app_label, model_name, setting_name, value.name
-            )
-            saved_name = default_storage.save(storage_path, value)
-
-            setting.value = saved_name
-            setting.save()
+        if files.is_file_setting(group_name, setting_name):
+            files.set_item(group_name, setting_name, setting, value)
             return
-
-        # user cleared the value. If file, delete the old stored file.
-        if not value:
-            if _is_file_setting(group_name, setting_name):
-                _delete_storage_name(old_storage_value)
 
         setting.value = value
         setting.save()

--- a/djpwr_app_settings/files.py
+++ b/djpwr_app_settings/files.py
@@ -1,0 +1,51 @@
+"""File-related handling for FileField-based app settings."""
+
+from django.core.files.uploadedfile import UploadedFile
+from django.db.models import FileField
+from djpwr.managers import get_model
+
+
+def set_item(group_name: str, setting_name: str, setting, new_value) -> None:
+    """Save or clear a file setting, respecting the field's storage and upload_to."""
+    field = _setting_model_field(group_name, setting_name)
+    old_storage_value = setting.value or ""
+
+    if not new_value:
+        _delete_file(field, old_storage_value)
+        setting.value = new_value
+    elif not isinstance(new_value, UploadedFile):
+        # FieldFile or string path — already stored, nothing to do
+        return
+    else:
+        _delete_file(field, old_storage_value)
+        model = get_model(group_name)
+        upload_path = field.generate_filename(model(), new_value.name)
+        saved_name = field.storage.save(upload_path, new_value)
+        setting.value = saved_name
+
+    setting.save()
+
+
+def is_file_setting(group_name: str, setting_name: str) -> bool:
+    """Return True if the setting corresponds to a FileField."""
+    field = _setting_model_field(group_name, setting_name)
+    return isinstance(field, FileField)
+
+
+def _setting_model_field(group_name: str, setting_name: str):
+    """Return the model field for a setting, or None if not found."""
+    try:
+        model = get_model(group_name)
+        return model._meta.get_field(setting_name)
+    except Exception:
+        return None
+
+
+def _delete_file(field: FileField, name: str) -> None:
+    """Delete a file from storage, silently ignoring errors."""
+    if not name:
+        return
+    try:
+        field.storage.delete(name)
+    except Exception:
+        pass


### PR DESCRIPTION
This change updates file-backed settings to be persisted via Django’s default_storage. Uploaded files are saved to storage and only the resulting storage path is stored in the setting value. When reading a file setting, the stored path is resolved back into a File object.

The update also handles cleanup of replaced or cleared file values and preserves compatibility with existing stored file settings.