### PR TITLE
add default_related_name='+' to SettingGroupMeta

### DIFF
--- a/djpwr_app_settings/models.py
+++ b/djpwr_app_settings/models.py
@@ -79,5 +79,6 @@ class ApplicationSetting(models.Model):
 
 class SettingGroupMeta:
     managed = False
+    default_related_name = '+'  # disable reverse accessor, avoids cross-app clashes
     verbose_name = _("Settings")
     verbose_name_plural = _("Settings")


### PR DESCRIPTION
Add default_related_name='+' to SettingGroupMeta to prevent cross-app reverse accessor clashes